### PR TITLE
Typo in executed Python file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The framework is designed to work directly with your local computer. Here's how 
 
 1. Run the example application:
 ```bash
-python app.py --instructions "Open web browser and go to microsoft.com"
+python main.py --instructions "Open web browser and go to microsoft.com"
 ```
 
 2. The AI model will:


### PR DESCRIPTION
CLI command refers to "app.py", while the repo provides "main.py". Probably a typo, because of the reference to the previous file name, that has changed.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Documentation refers to non-existing app.py. The repo comes with main.py file instead, that should be referred to in the  given CLI command.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ x ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Execute CLI command with corrected file reference.

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
CLI commands executes successfully.

## Other Information
<!-- Add any other helpful information that may be needed here. -->